### PR TITLE
Merge options instead of concatenating them

### DIFF
--- a/lib/std_json_io.ex
+++ b/lib/std_json_io.ex
@@ -10,7 +10,7 @@ defmodule StdJsonIo do
     quote do
       use Supervisor
       @pool_name Module.concat(__MODULE__, Pool)
-      @options unquote(opts) ++ (Application.get_env(unquote(otp_app), __MODULE__) || [])
+      @options Keyword.merge(unquote(opts), (Application.get_env(unquote(otp_app), __MODULE__) || []))
 
 
       def start_link(opts \\ []) do


### PR DESCRIPTION
With existing approach, I'm getting `@options` equal to:

``` elixir
[otp_app: :my_app, script: "react-stdio", pool_size: 4, max_overflow: 8, script: "/home/user/projects/my_app/node_modules/react-stdio/bin/react-stdio"]
```

because of `++` only appends options to the last of the list. This leads to unexpected result.

With new approch `@opts` is:

``` elixir
[otp_app: :brutalist, pool_size: 4, max_overflow: 8, script: "/home/user/projects/my_app/node_modules/react-stdio/bin/react-stdio"]
```
