### PR TITLE
Add :fs to included applications to make it works with releases

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,10 @@ defmodule StdJsonIo.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :porcelain]]
+    [
+      applications: [:logger, :porcelain],
+      included_applications: [:fs]
+    ]
   end
 
   def docs do


### PR DESCRIPTION
Hello @hassox,

unfortunately, `std_json_io` doesn't work with release managers like `exrm` or `distillary`. It happens because `:fs` isn't specified in `applications` in `mix.exs`. But we don't have to specify it, because its start is optional, so, the idea is pretty simple - add it to `included_applications`. You can read issue here: https://github.com/bitwalker/exrm/issues/345

I tested it, it works!
