### PR TITLE
Updated Poison dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule StdJsonIo.Mixfile do
     [
       {:porcelain, "~> 2.0"},
       {:poolboy, "~> 1.5.1"},
-      {:poison, "~> 1.5.0"},
+      {:poison, "~> 2.2"},
       {:fs, "~> 0.9.1"},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{"fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
-  "poison": {:hex, :poison, "1.5.0", "f2f4f460623a6f154683abae34352525e1d918380267cdbd949a07ba57503248", [:mix], []},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
   "porcelain": {:hex, :porcelain, "2.0.1", "9c3db2b47d8cf6879c0d9ac79db8657333974a88faff09e856569e00c1b5e119", [:mix], []}}


### PR DESCRIPTION
Hi, I am in the process of integrating server-side react rendering with a Phoenix application, and I couldn't use the latest release on hex.pm because of a dependency version conflict with Phoenix.

I'm following this guide:
http://blog.overstuffedgorilla.com/render-react-with-phoenix/
(and thanks for the great writeup!)


This PR updates the poison dependency to make the library compatible with Phoenix 1.2.1
This also silences all the "unsafe variable assignment" warnings.