### PR TITLE
fix for change of gen_server behaviour introduced in 1.4 elixir 

### DIFF
--- a/lib/std_json_io.ex
+++ b/lib/std_json_io.ex
@@ -14,7 +14,7 @@ defmodule StdJsonIo do
 
 
       def start_link(opts \\ []) do
-        Supervisor.start_link(__MODULE__, :ok, name: {:local, __MODULE__})
+        Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
       end
 
       def init(:ok) do

--- a/lib/std_json_io/reloader.ex
+++ b/lib/std_json_io/reloader.ex
@@ -2,7 +2,7 @@ defmodule StdJsonIo.Reloader do
   use GenServer
 
   def start_link(mod, files) do
-    GenServer.start_link(__MODULE__, [mod, files], name: {:local, __MODULE__})
+    GenServer.start_link(__MODULE__, [mod, files], name: __MODULE__)
   end
 
   def init([mod, files]) do


### PR DESCRIPTION
The following change to gen_server
https://github.com/elixir-lang/elixir/commit/d9cdeeb2f135abcac87a30b35169efe5d3d7e94c
resulted in errors being thrown calling the start_link functions. 
Looking at the previous state of lib/elixir/lib/gen_server.ex
i don't believe that these changes would break under older versions of elixir
as it would fall into the 
{atom, opts} when is_atom(atom) ->
          :gen.start(:gen_server, link, {:local, atom}, module, args, opts)
case
However i have only been learning elixir for a total of 2 days